### PR TITLE
Fix: Added missing namespace to android/build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,8 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 33
+    namespace "com.sidlatau.flutterdocumentpicker"
+
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
build.gradle file is missing the namespace declaration, which is required in AGP (Android Gradle Plugin) 7+. Since using Gradle 3.6.4, the missing namespace  causing the error.